### PR TITLE
import gdb python module

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Dumps Lua execution stack, as debug.traceback() does. Without arguments, uses th
 
 Print all variables of the function at level 'f' of the stack 'coroutine'. With no arguments, Dump all variables of the current funtion in the stack of 'L'.
 
+## Install
+
+```
+sudo cp lua-gdb.py /usr/share/gdb/python/
+```
+
 ## Usage (step by step)
 
 * compile lua with debug symbols
@@ -64,7 +70,7 @@ will hit the breakpoint `os_time`.
 
 * load the extension
 ```
-(gdb) source lua-gdb.py
+(gdb) py import lua-gdb.py
 Loading Lua Runtime support.
 ```
 

--- a/lua-gdb.py
+++ b/lua-gdb.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import gdb
 import re
 import sys
 


### PR DESCRIPTION
`lua-gdb.py` is depending on gdb python module, so we should import it.