### PR TITLE
Fix infinite loop when table has holes in the array part

### DIFF
--- a/examples/dbg.lua
+++ b/examples/dbg.lua
@@ -1,6 +1,7 @@
 local t = {
     "hello",
     "world",
+    1, 2, 3,
     vacant = nil,
     boolean = true,
     int = 5,
@@ -10,7 +11,9 @@ local t = {
     func = function() end,
     co = coroutine.create(function() end),
 }
-
+-- hole
+t[4] = nil
+print(#t)
 -- loop
 t.t = t
 

--- a/lua-gdb.py
+++ b/lua-gdb.py
@@ -425,6 +425,7 @@ class TablePrinter:
         while i < sizearray:
             val = self.val['array'][i]
             if ttisnil(val):
+                i = i + 1
                 continue
             yield str(2*i), i
             yield str(2*i + 1), val


### PR DESCRIPTION
See the updated `examples/dbg.lua` file for the issue. When trying to print the table "t", it gets stuck in an infinite loop.

I fixed this by incrementing the loop counter before continuing.